### PR TITLE
No Breaking Change MonitoringStream.cs

### DIFF
--- a/src/Nerdbank.Streams/MonitoringStream.cs
+++ b/src/Nerdbank.Streams/MonitoringStream.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace MyMonitoringStream
+namespace Nerdbank.Streams
 {
     using System;
     using System.IO;


### PR DESCRIPTION
Aimed to avoid breaking changes when updating from versions previous to 2.11.79.
Added WillReadArraySegment, DidReadArraySegment, WillWriteArraySegment and, DidWriteArraySegment events to be fired when ArraySegments api's are used. WillRead, DidRead, WillWrite and, DidWrite will be fired when any corresponding api is used.
Remark: The non sufixed events will allocate memory and it's recomended to use the specifics events for each api, however existing proyects can update dependency without breaking changes.